### PR TITLE
Rewrite tests using pytest and mock external APIs

### DIFF
--- a/src/ai/ai_manager.py
+++ b/src/ai/ai_manager.py
@@ -139,6 +139,8 @@ class AIManager:
         bool
             ``True`` if the backend exists and was activated, ``False`` otherwise.
         """
+        if backend == self._current_backend:
+            return True
         if backend in self.backends:
             self._current_backend = backend
             return True

--- a/src/ai/ai_manager.py
+++ b/src/ai/ai_manager.py
@@ -126,6 +126,24 @@ class AIManager:
         """Get the name of the current backend"""
         return self._current_backend
 
+    def switch_backend(self, backend: Literal["claude", "llama"]) -> bool:
+        """Switch the active backend.
+
+        Parameters
+        ----------
+        backend: Literal["claude", "llama"]
+            Name of the backend to activate.
+
+        Returns
+        -------
+        bool
+            ``True`` if the backend exists and was activated, ``False`` otherwise.
+        """
+        if backend in self.backends:
+            self._current_backend = backend
+            return True
+        return False
+
     def _construct_prompt(
         self, user_input: str, game_state: Optional[Dict[str, Any]] = None
     ) -> str:


### PR DESCRIPTION
## Summary
- add `switch_backend` to `AIManager`
- rewrite `test_ai.py` with pytest and mocks
- rewrite `test_enhanced_ai.py` using `AIManager` and pytest

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684eec30a3ec8328aa3aae5209494da3