### PR TITLE
Add backend switching validation

### DIFF
--- a/src/ai/ai_manager.py
+++ b/src/ai/ai_manager.py
@@ -132,24 +132,30 @@ class AIManager:
         """Get the name of the current backend"""
         return self._current_backend
 
-    def switch_backend(self, backend: Literal["claude", "llama"]) -> bool:
-        """Switch the active backend.
+    def switch_backend(self, name: str) -> bool:
+        """Attempt to switch the active backend.
 
         Parameters
         ----------
-        backend: Literal["claude", "llama"]
+        name: str
             Name of the backend to activate.
 
         Returns
         -------
         bool
-            ``True`` if the backend exists and was activated, ``False`` otherwise.
+            ``True`` if the backend exists, is available and was activated,
+            ``False`` otherwise.
         """
-        if backend == self._current_backend:
+        if name == self._current_backend:
             return True
-        if backend in self.backends:
-            self._current_backend = backend
+
+        backend = self.backends.get(name)
+        if backend and backend.is_available():
+            self._current_backend = name
+            logger.info(f"Switched AI backend to {name}")
             return True
+
+        logger.warning(f"Requested backend '{name}' is not available")
         return False
 
     def _construct_prompt(

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -104,8 +104,12 @@ async def process_command(command: GameCommand) -> GameResponse:
                 game_state = get_game_state()
                 state_dict = game_state.dict() if game_state else {}
 
-                if command.model != ai_manager._current_backend:
-                    ai_manager.switch_backend(command.model)
+                if command.model != ai_manager.current_backend:
+                    if not ai_manager.switch_backend(command.model):
+                        raise HTTPException(
+                            status_code=500,
+                            detail=f"Model {command.model} unavailable",
+                        )
 
                 ai_response = ai_manager.get_ai_response(command.command, state_dict)
                 response = f"{response}\n\n{ai_response}"

--- a/test_enhanced_ai.py
+++ b/test_enhanced_ai.py
@@ -55,3 +55,17 @@ def test_fallback_to_llama(mocked_manager):
     response = manager.get_ai_response("hello")
     assert response == "llama"
     llama_model.assert_called()
+
+
+def test_switch_backend_invalid_name(mocked_manager):
+    manager, _, _ = mocked_manager
+    assert not manager.switch_backend("invalid")
+    assert manager.current_backend == "claude"
+
+
+def test_switch_backend_unavailable(mocked_manager):
+    manager, _, _ = mocked_manager
+    # Make llama unavailable
+    manager.backends["llama"].model = None
+    assert not manager.switch_backend("llama")
+    assert manager.current_backend == "claude"


### PR DESCRIPTION
## Summary
- validate backend availability in AI manager
- enforce backend availability check when processing commands
- test invalid and unavailable backend switches

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ef860f7a8832880ffb2874dbc3442