### PR TITLE
Add API base URL setting for frontend

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -7,3 +7,6 @@ PORT=8000
 
 # Development Settings
 DEBUG=True
+
+# Frontend Configuration
+VITE_API_BASE_URL=http://localhost:8000

--- a/frontend/.env.template
+++ b/frontend/.env.template
@@ -1,0 +1,2 @@
+# Frontend Environment Settings
+VITE_API_BASE_URL=http://localhost:8000

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -5,4 +5,15 @@ This template provides a minimal setup to get React working in Vite with HMR and
 Currently, two official plugins are available:
 
 - [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+ - [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+
+## Environment Variables
+
+Create a `.env` file in this directory to configure the frontend. Set
+`VITE_API_BASE_URL` to the URL of the backend API:
+
+```
+VITE_API_BASE_URL=http://localhost:8000
+```
+
+If omitted, the application falls back to `http://localhost:8000`.

--- a/frontend/src/components/GameInterface.tsx
+++ b/frontend/src/components/GameInterface.tsx
@@ -4,6 +4,8 @@ import ModelSelector from './ModelSelector';
 import MessageList from './MessageList';
 import { GameState, Message } from './types';
 
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000';
+
 const GameInterface: React.FC = () => {
     const [messages, setMessages] = useState<Message[]>([]);
     const [inputText, setInputText] = useState('');
@@ -27,7 +29,7 @@ const GameInterface: React.FC = () => {
 
     const startGame = async () => {
         try {
-            const response = await fetch('http://localhost:8000/game/start');
+            const response = await fetch(`${API_BASE_URL}/game/start`);
             const data = await response.json();
             addMessage('system', data.message);
         } catch (error) {
@@ -39,7 +41,7 @@ const GameInterface: React.FC = () => {
     const switchModel = async (newModel: 'claude' | 'llama') => {
         try {
             setIsModelSwitching(true);
-            const response = await fetch('http://localhost:8000/game/switch-model', {
+            const response = await fetch(`${API_BASE_URL}/game/switch-model`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ model: newModel }),
@@ -70,7 +72,7 @@ const GameInterface: React.FC = () => {
         setIsThinking(true);
 
         try {
-            const response = await fetch('http://localhost:8000/game/command', {
+            const response = await fetch(`${API_BASE_URL}/game/command`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({


### PR DESCRIPTION
## Summary
- add `VITE_API_BASE_URL` support in GameInterface fetch calls
- document the new variable in frontend README
- provide `.env.template` for the frontend and update root template

## Testing
- `pytest -q`
- `npm run lint` *(fails: require is not defined)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684f05dcd3388328933a288dda3f418e