### PR TITLE
Add pre-commit setup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+        language_version: python3
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.0.0
+    hooks:
+      - id: flake8
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: v9.29.0
+    hooks:
+      - id: eslint

--- a/README.md
+++ b/README.md
@@ -122,6 +122,17 @@ Run this from the project root so package imports resolve correctly.
 
 ## Development
 
+### Pre-commit Hooks
+
+Set up Git hooks to automatically lint and format your code:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+This config runs `black`, `flake8`, and `eslint` on each commit.
+
 ### Key Components
 
 1. **AI Manager** (`src/ai/ai_manager.py`)


### PR DESCRIPTION
## Summary
- add `.pre-commit-config.yaml`
- document how to install and use pre-commit hooks

## Testing
- `pre-commit run --files README.md .pre-commit-config.yaml`
- `pytest -q` *(fails: ModuleNotFoundError: 'anthropic')*

------
https://chatgpt.com/codex/tasks/task_e_684f0b8b5b74832882a070694f72680c