### PR TITLE
Add LLAMA_MODEL_PATH to env template

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,5 +1,6 @@
 # API Keys
 ANTHROPIC_API_KEY=your_api_key_here
+LLAMA_MODEL_PATH=/path/to/your/model.gguf
 
 # Server Configuration
 HOST=localhost


### PR DESCRIPTION
## Summary
- include `LLAMA_MODEL_PATH` in `.env.template`
- documentation already covers this variable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f12a057d88328840e0256cbd6b60f