### PR TITLE
Add Docker setup

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+EXPOSE 8000
+CMD ["uvicorn", "src.api.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,0 +1,9 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY frontend/package*.json ./frontend/
+RUN cd frontend && npm ci
+COPY frontend ./frontend
+WORKDIR /app/frontend
+EXPOSE 5173
+ENV VITE_API_BASE_URL=http://backend:8000
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -120,6 +120,20 @@ Run this from the project root so package imports resolve correctly.
 
 2. Access the game at: http://localhost:5173
 
+## Docker Usage
+
+You can also run the project using Docker. Build the containers and start both
+services with `docker compose`:
+
+```bash
+docker compose build
+docker compose up
+```
+
+The backend API will be available on `http://localhost:8000` and the frontend on
+`http://localhost:5173`. Ensure you have a `.env` file in the project root so
+the backend container can read your API keys.
+
 ## Development
 
 ### Pre-commit Hooks

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3'
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile.backend
+    env_file:
+      - .env
+    ports:
+      - "8000:8000"
+  frontend:
+    build:
+      context: .
+      dockerfile: Dockerfile.frontend
+    environment:
+      - VITE_API_BASE_URL=http://backend:8000
+    ports:
+      - "5173:5173"
+    depends_on:
+      - backend


### PR DESCRIPTION
## Summary
- add backend and frontend Dockerfiles
- create docker-compose file to run both services together
- document Docker usage in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f13b8f1508328802d5fe35b683210