### PR TITLE
Add CORS_ORIGINS env variable

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -4,6 +4,8 @@ ANTHROPIC_API_KEY=your_api_key_here
 # Server Configuration
 HOST=localhost
 PORT=8000
+# Comma-separated list of allowed origins for CORS
+CORS_ORIGINS=http://localhost:5173
 
 # Development Settings
 DEBUG=True

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Copy `.env.template` to `.env` and add your settings:
 ```
 ANTHROPIC_API_KEY=your_api_key_here
 LLAMA_MODEL_PATH=/path/to/your/model.gguf  # Optional
+CORS_ORIGINS=http://localhost:5173  # Allowed origins for CORS
 ```
 
 ### Model Setup

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -1,4 +1,6 @@
 import logging
+import os
+from dotenv import load_dotenv
 
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
@@ -8,6 +10,9 @@ from typing import Optional, Dict, List, Literal
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+# Load environment variables from .env if available
+load_dotenv()
 
 
 # Model classes
@@ -45,9 +50,14 @@ except Exception as e:
 app = FastAPI(title="Dark Station Chronicles API")
 
 # Configure CORS
+# Allow origins can be provided as a comma-separated list via CORS_ORIGINS
+# environment variable. Defaults to localhost dev server.
+origins_env = os.getenv("CORS_ORIGINS", "http://localhost:5173")
+allow_origins = [o.strip() for o in origins_env.split(",") if o.strip()]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:5173"],
+    allow_origins=allow_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Summary
- allow overriding allowed CORS origins via `CORS_ORIGINS` environment variable
- document new variable in README and `.env.template`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f2cf3c8b88328865f0d16344de822