### PR TITLE
Add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,7 @@
 .git
 **/node_modules/
 venv
-tests
+tests/
 **/__pycache__/
 *.pyc
 *.pyo


### PR DESCRIPTION
## Summary
- create `.dockerignore` to avoid copying unneeded files into Docker build context

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'anthropic')*
- `docker build -f Dockerfile.backend -t backend-noignore .` *(fails: Cannot connect to the Docker daemon)*
- `docker build -f Dockerfile.backend -t backend-ignore .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_684f2cee000c832898e25981ad6c8de5