### PR TITLE
Add missing React UI components

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import reactLogo from './assets/react.svg'
 import viteLogo from '/vite.svg'
 import './App.css'
-import GameInterface from './GameInterface'
+import GameInterface from './components/GameInterface'
 
 function App() {
   const [count, setCount] = useState(0)

--- a/frontend/src/components/MessageList.tsx
+++ b/frontend/src/components/MessageList.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Message } from '../types';
+
+interface MessageListProps {
+  messages: Message[];
+}
+
+const MessageList = React.forwardRef<HTMLDivElement, MessageListProps>(({ messages }, ref) => {
+  return (
+    <div className="flex-1 overflow-y-auto p-4 space-y-2" data-testid="message-list">
+      {messages.map((msg, idx) => (
+        <div key={idx} className={msg.type === 'error' ? 'text-red-400' : msg.type === 'player' ? 'text-green-300' : ''}>
+          {msg.content}
+        </div>
+      ))}
+      <div ref={ref} />
+    </div>
+  );
+});
+
+export default MessageList;

--- a/frontend/src/components/ModelSelector.tsx
+++ b/frontend/src/components/ModelSelector.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+export type AIModel = 'claude' | 'llama' | 'openai' | 'gemini' | 'openrouter';
+
+interface ModelSelectorProps {
+  currentModel: AIModel;
+  isSwitching?: boolean;
+  onSwitch: (model: AIModel) => void;
+}
+
+const ModelSelector: React.FC<ModelSelectorProps> = ({ currentModel, isSwitching = false, onSwitch }) => {
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    onSwitch(e.target.value as AIModel);
+  };
+
+  return (
+    <div className="mb-4" data-testid="model-selector">
+      <label htmlFor="model" className="block text-sm font-semibold mb-1">AI Model</label>
+      <select
+        id="model"
+        value={currentModel}
+        onChange={handleChange}
+        disabled={isSwitching}
+        className="w-full bg-gray-700 p-2 rounded"
+      >
+        <option value="claude">Claude</option>
+        <option value="llama">Llama</option>
+        <option value="openai">OpenAI</option>
+        <option value="gemini">Gemini</option>
+        <option value="openrouter">OpenRouter</option>
+      </select>
+    </div>
+  );
+};
+
+export default ModelSelector;

--- a/frontend/src/components/StatsPanel.tsx
+++ b/frontend/src/components/StatsPanel.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { PlayerStats } from '../types';
+
+interface StatsPanelProps {
+  stats: PlayerStats;
+}
+
+const StatsPanel: React.FC<StatsPanelProps> = ({ stats }) => {
+  return (
+    <div className="mt-4 text-sm" data-testid="stats-panel">
+      <h3 className="font-semibold mb-2">Player Stats</h3>
+      <ul className="space-y-1">
+        {Object.entries(stats).map(([key, value]) => (
+          <li key={key} className="flex justify-between">
+            <span className="capitalize">{key.replace('_', ' ')}</span>
+            <span>{String(value)}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default StatsPanel;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,0 +1,25 @@
+export interface PlayerStats {
+  health: number;
+  energy: number;
+  level: number;
+  exp: number;
+  [key: string]: number; // allow additional stats
+}
+
+export interface GameState {
+  current_room: string;
+  player_stats: PlayerStats;
+  inventory: string[];
+  available_exits: string[];
+  character_class?: string | null;
+}
+
+export interface Message {
+  type: 'system' | 'player' | 'error';
+  content: string;
+}
+
+export interface SaveFile {
+  filename: string;
+  timestamp: string;
+}


### PR DESCRIPTION
## Summary
- implement frontend StatsPanel, ModelSelector and MessageList
- create shared type definitions in `types.ts`
- fix `App.jsx` import path for GameInterface

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm install`
- `npm run build`
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_684f641c746883288120ac9b8f2e6880