### PR TITLE
Add session management

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -93,8 +93,9 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-# Simple in-memory session store
-sessions: Dict[str, StoryManager] = {}
+# Simple in-memory session store with TTL
+sessions: Dict[str, Dict[str, Any]] = {}  # Stores {'manager': StoryManager, 'last_access': datetime}
+SESSION_TTL_SECONDS = int(os.getenv("SESSION_TTL_SECONDS", "3600"))  # Default TTL is 1 hour
 
 
 # Dependency providers

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -1,10 +1,11 @@
 import logging
 import os
 import datetime  # Added for timestamping save files
+import uuid
 from dotenv import load_dotenv
 from typing import Optional, Dict, List, Literal, Any  # Added Any
 
-from fastapi import FastAPI, HTTPException, Depends
+from fastapi import FastAPI, HTTPException, Depends, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
@@ -92,12 +93,23 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+# Simple in-memory session store
+sessions: Dict[str, StoryManager] = {}
+
 
 # Dependency providers
-def get_story_manager() -> StoryManager:
-    """Create a new StoryManager for each request."""
+def get_story_manager(request: Request, response: Response) -> StoryManager:
+    """Retrieve or create a StoryManager tied to a session."""
     try:
-        return StoryManager()
+        session_id = request.cookies.get("session-id")
+        if session_id and session_id in sessions:
+            return sessions[session_id]
+
+        story_manager = StoryManager()
+        session_id = str(uuid.uuid4())
+        sessions[session_id] = story_manager
+        response.set_cookie("session-id", session_id, httponly=True)
+        return story_manager
     except Exception as e:
         logger.error(f"Error creating StoryManager: {e}")
         raise

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -109,7 +109,7 @@ def get_story_manager(request: Request, response: Response) -> StoryManager:
         story_manager = StoryManager()
         session_id = str(uuid.uuid4())
         sessions[session_id] = story_manager
-        response.set_cookie("session-id", session_id, httponly=True)
+        response.set_cookie("session-id", session_id, httponly=True, secure=True, samesite="Lax")
         return story_manager
     except Exception as e:
         logger.error(f"Error creating StoryManager: {e}")

--- a/test_api_endpoints.py
+++ b/test_api_endpoints.py
@@ -17,8 +17,15 @@ def create_client(monkeypatch):
     monkeypatch.setitem(
         module.app.dependency_overrides, module.get_ai_manager, lambda: mock_ai
     )
+    def override_story_manager(
+        request: main.Request, response: main.Response
+    ) -> main.StoryManager:
+        return story_manager
+
     monkeypatch.setitem(
-        module.app.dependency_overrides, module.get_story_manager, lambda: story_manager
+        module.app.dependency_overrides,
+        module.get_story_manager,
+        override_story_manager,
     )
 
     client = TestClient(module.app)

--- a/test_save_load_endpoints.py
+++ b/test_save_load_endpoints.py
@@ -20,8 +20,19 @@ def create_client(monkeypatch, tmp_path):
     mock_ai.switch_backend.return_value = True
 
     story = module.StoryManager()
-    monkeypatch.setitem(module.app.dependency_overrides, module.get_ai_manager, lambda: mock_ai)
-    monkeypatch.setitem(module.app.dependency_overrides, module.get_story_manager, lambda: story)
+    monkeypatch.setitem(
+        module.app.dependency_overrides, module.get_ai_manager, lambda: mock_ai
+    )
+    def override_story_manager(
+        request: main.Request, response: main.Response
+    ) -> main.StoryManager:
+        return story
+
+    monkeypatch.setitem(
+        module.app.dependency_overrides,
+        module.get_story_manager,
+        override_story_manager,
+    )
 
     client = TestClient(module.app)
     return client, module, story

--- a/test_save_load_endpoints.py
+++ b/test_save_load_endpoints.py
@@ -23,9 +23,7 @@ def create_client(monkeypatch, tmp_path):
     monkeypatch.setitem(
         module.app.dependency_overrides, module.get_ai_manager, lambda: mock_ai
     )
-    def override_story_manager(
-        request: main.Request, response: main.Response
-    ) -> main.StoryManager:
+    def override_story_manager() -> main.StoryManager:
         return story
 
     monkeypatch.setitem(

--- a/test_sessions.py
+++ b/test_sessions.py
@@ -1,0 +1,32 @@
+import importlib
+from unittest.mock import MagicMock
+from fastapi.testclient import TestClient
+
+import src.api.main as main
+
+
+def create_client(monkeypatch):
+    module = importlib.reload(main)
+    module.sessions.clear()
+    mock_ai = MagicMock()
+    mock_ai.current_backend = "claude"
+    mock_ai.get_ai_response.return_value = "ai"
+    mock_ai.switch_backend.return_value = True
+    monkeypatch.setitem(module.app.dependency_overrides, module.get_ai_manager, lambda: mock_ai)
+    return TestClient(module.app), module
+
+
+def test_session_creation(monkeypatch):
+    client, module = create_client(monkeypatch)
+    response = client.get("/game/start")
+    assert response.status_code == 200
+    session_id = response.cookies.get("session-id")
+    assert session_id in module.sessions
+
+
+def test_session_reuse(monkeypatch):
+    client, module = create_client(monkeypatch)
+    client.get("/game/start")
+    client.post("/game/command", json={"command": "north", "use_ai": False})
+    state = client.get("/game/state")
+    assert state.json()["current_room"] == "corridor"


### PR DESCRIPTION
## Summary
- store StoryManager instances in a global session dictionary
- use cookies to identify and reuse sessions
- adjust endpoint tests for session-aware dependency overrides
- add tests for session creation and reuse

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f6c1a222c8328a29d8a762a9bf90c