### PR TITLE
Add pre-commit instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ This will:
 - Set up a virtual environment
 - Install Python dependencies
 - Configure the frontend
+- Install Git hooks with `pre-commit install`
 
 ### Environment Configuration
 Copy `.env.template` to `.env` and add your settings:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
-pytest
 httpx
+pre-commit
+pytest


### PR DESCRIPTION
## Summary
- document git hook setup in README
- include `pre-commit` in dev requirements

## Testing
- `pre-commit run --files README.md requirements-dev.txt`

------
https://chatgpt.com/codex/tasks/task_e_684f758656d88328b440b10faaea60b5