### PR TITLE
Refactor model literals

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -175,6 +175,7 @@ response = ai_manager.generate_response(
 - `GameCommand`: Player input with AI options
 - `GameState`: Complete game state representation
 - `SwitchModelRequest`: Model switching requests
+- `MODEL_NAMES`: Tuple listing valid AI backend identifiers
 
 ### 4. Game Interface (`frontend/src/components/GameInterface.tsx`)
 

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -3,7 +3,7 @@ import os
 import datetime  # Added for timestamping save files
 import uuid
 from dotenv import load_dotenv
-from typing import Optional, Dict, List, Literal, Any  # Added Any
+from typing import Optional, Dict, List, Literal, Any
 
 from fastapi import FastAPI, HTTPException, Depends, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
@@ -18,29 +18,26 @@ logger = logging.getLogger(__name__)
 load_dotenv()
 
 
+# Tuple of supported AI model names used throughout the API
+MODEL_NAMES: tuple[str, ...] = (
+    "claude",
+    "llama",
+    "openai",
+    "gemini",
+    "openrouter",
+)
+
 # --- Model classes ---
 
 
 class SwitchModelRequest(BaseModel):
-    model: Literal[
-        "claude",
-        "llama",
-        "openai",
-        "gemini",
-        "openrouter",
-    ]
+    model: Literal[*MODEL_NAMES]
 
 
 class GameCommand(BaseModel):
     command: str
     use_ai: bool = False
-    model: Literal[
-        "claude",
-        "llama",
-        "openai",
-        "gemini",
-        "openrouter",
-    ] = "claude"
+    model: Literal[*MODEL_NAMES] = "claude"
 
 
 class GameState(BaseModel):


### PR DESCRIPTION
## Summary
- centralize supported model names in `MODEL_NAMES`
- use `Literal[*MODEL_NAMES]` for model selection fields
- document `MODEL_NAMES` in agent guide

## Testing
- `COOKIE_SECURE=False pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f7a1b6cfc8328ae99fce498c220f4